### PR TITLE
Add Supabase authentication with login and signup forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Anclora es una aplicación web de productividad personal que permite a los usuar
 
 ## Configuración de Supabase
 
-La aplicación está configurada para conectarse a Supabase con las siguientes credenciales:
+La aplicación utiliza variables de entorno para conectarse a Supabase. Crea un archivo `.env` (o configura las variables en tu entorno) con:
 
-```javascript
-const SUPABASE_URL = 'https://kehpwxdkpdxapfxwhfwn.supabase.co'
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+```bash
+VITE_SUPABASE_URL="https://tu-proyecto.supabase.co"
+VITE_SUPABASE_ANON_KEY="tu_anon_key"
 ```
 
 ### Estructura de Base de Datos Esperada
@@ -94,7 +94,7 @@ La aplicación espera las siguientes tablas en Supabase:
    ```
 
 3. **Configurar variables de entorno**
-   - Actualizar las credenciales de Supabase en `src/App.jsx`
+   - Crea un archivo `.env` con `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY`
 
 4. **Ejecutar en desarrollo**
    ```bash

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,12 @@
 // src/App.jsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, createContext } from 'react';
 import { BrowserRouter as Router, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import logoAnclora from './assets/Logo_Anclora_App.png';
+import SignUpForm from '@/components/Auth/SignUpForm.jsx';
+import LoginForm from '@/components/Auth/LoginForm.jsx';
+import supabase from '@/lib/supabase.js';
+
+export const AuthContext = createContext(null);
 
 // Paleta de colores expandida con 8 colores adicionales
 const colors = {
@@ -1286,11 +1291,11 @@ function Dashboard() {
     minWidth: '150px'
   };
 
-  const sectionsGridStyle = {
-    display: 'grid',
-    gridTemplateColumns: '1fr',
-    gap: '32px'
-  };
+  // const sectionsGridStyle = {
+  //   display: 'grid',
+  //   gridTemplateColumns: '1fr',
+  //   gap: '32px'
+  // };
 
   const sectionStyle = {
     backgroundColor: colors.white,
@@ -2102,15 +2107,35 @@ function Dashboard() {
 }
 
 function App() {
+  const [session, setSession] = useState(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session)
+    })
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/dashboard-selection" element={<DashboardSelection />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/dashboard/:audience" element={<Dashboard />} />
-      </Routes>
-    </Router>
+    <AuthContext.Provider value={session}>
+      <Router>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/dashboard-selection" element={<DashboardSelection />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/dashboard/:audience" element={<Dashboard />} />
+          <Route path="/signup" element={<SignUpForm />} />
+          <Route path="/login" element={<LoginForm />} />
+        </Routes>
+      </Router>
+    </AuthContext.Provider>
   );
 }
 

--- a/src/components/Auth/LoginForm.jsx
+++ b/src/components/Auth/LoginForm.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+import supabase from '@/lib/supabase'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+function LoginForm() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) setError(error.message)
+    setLoading(false)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto mt-8 space-y-4">
+      <Input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <Input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <Button type="submit" disabled={loading}>
+        {loading ? 'Ingresando...' : 'Iniciar sesión'}
+      </Button>
+    </form>
+  )
+}
+
+export default LoginForm

--- a/src/components/Auth/SignUpForm.jsx
+++ b/src/components/Auth/SignUpForm.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+import supabase from '@/lib/supabase'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+function SignUpForm() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    const { error } = await supabase.auth.signUp({ email, password })
+    if (error) setError(error.message)
+    setLoading(false)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto mt-8 space-y-4">
+      <Input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <Input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <Button type="submit" disabled={loading}>
+        {loading ? 'Creando cuenta...' : 'Registrarse'}
+      </Button>
+    </form>
+  )
+}
+
+export default SignUpForm

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+export default supabase

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- create Supabase client helper
- add signup and login forms under `components/Auth`
- integrate auth state handling and new routes in `App.jsx`
- update Vite config to work with eslint
- document new environment variables and setup in README
- ignore `node_modules`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686bc1063c588320ab2c5c7be24f9079